### PR TITLE
Add a source picker to the properties pane

### DIFF
--- a/src/pipewire.c
+++ b/src/pipewire.c
@@ -179,6 +179,8 @@ struct _obs_pipewire_stream {
 	struct crop_info crop;
 	enum spa_meta_videotransform_value transform;
 	uint32_t width, height;
+
+	uint32_t link_id;
 };
 
 /* auxiliary methods */
@@ -1882,4 +1884,72 @@ void obs_pipewire_stream_set_name(obs_pipewire_stream *obs_pw_stream, const char
 
 	/* Signal to rename */
 	pw_loop_signal_event(pw_thread_loop_get_loop(obs_pw->thread_loop), obs_pw_stream->rename);
+}
+
+void on_link_proxy_bound_cb(void *data, uint32_t global_id)
+{
+	obs_pipewire_stream *obs_pw_stream = (obs_pipewire_stream *)data;
+	obs_pw_stream->link_id = global_id;
+	blog(LOG_INFO, "[pipewire] Created link %u", obs_pw_stream->link_id);
+}
+
+void on_link_proxy_error_cb(void *data, int seq, int res, const char *message)
+{
+	UNUSED_PARAMETER(seq);
+	UNUSED_PARAMETER(res);
+
+	blog(LOG_INFO, "[pipewire] Link proxy error '%s'", message);
+
+	obs_pipewire_stream *obs_pw_stream = (obs_pipewire_stream *)data;
+
+	if (obs_pw_stream->link_id != 0) {
+		pw_registry_destroy(obs_pw_stream->obs_pw->registry, obs_pw_stream->link_id);
+		obs_pw_stream->link_id = 0;
+	}
+}
+
+static const struct pw_proxy_events link_proxy_events = {
+	.version = PW_VERSION_LINK_EVENTS,
+	.bound = on_link_proxy_bound_cb,
+	.error = on_link_proxy_error_cb,
+};
+
+void obs_pipewire_connect_to_output(obs_pipewire_stream *obs_pw_stream, uint32_t port_id)
+{
+	obs_pipewire *obs_pw = obs_pw_stream->obs_pw;
+	pw_thread_loop_lock(obs_pw->thread_loop);
+
+	blog(LOG_INFO, "[pipewire] Connecting stream to port %u", port_id);
+
+	if (obs_pw_stream->link_id != 0) {
+		pw_registry_destroy(obs_pw->registry, obs_pw_stream->link_id);
+		obs_pw_stream->link_id = 0;
+		obs_pw->sync_id = pw_core_sync(obs_pw->core, PW_ID_CORE, obs_pw->sync_id);
+		pw_thread_loop_wait(obs_pw->thread_loop);
+	}
+
+	char out_port[16], node_id[16];
+	snprintf(out_port, sizeof(out_port), "%u", port_id);
+	snprintf(node_id, sizeof(node_id), "%u", pw_stream_get_node_id(obs_pw_stream->stream));
+
+	struct spa_dict props;
+	struct spa_dict_item items[3];
+	props = SPA_DICT_INIT(items, 0);
+	items[props.n_items++] = SPA_DICT_ITEM_INIT(PW_KEY_LINK_OUTPUT_PORT, out_port);
+	items[props.n_items++] = SPA_DICT_ITEM_INIT(PW_KEY_LINK_INPUT_NODE,  node_id);
+	items[props.n_items++] = SPA_DICT_ITEM_INIT(PW_KEY_OBJECT_LINGER,    "true");
+
+	struct pw_proxy *link_proxy = (struct pw_proxy *)pw_core_create_object(obs_pw->core,
+		"link-factory", PW_TYPE_INTERFACE_Link, PW_VERSION_LINK, &props, 0);
+	if (link_proxy) {
+		struct spa_hook link_proxy_listener;
+		spa_zero(link_proxy_listener);
+		pw_proxy_add_listener(link_proxy, &link_proxy_listener, &link_proxy_events, obs_pw_stream);
+		obs_pw->sync_id = pw_core_sync(obs_pw->core, PW_ID_CORE, obs_pw->sync_id);
+		pw_thread_loop_wait(obs_pw->thread_loop);
+		spa_hook_remove(&link_proxy_listener);
+		pw_proxy_destroy(link_proxy);
+	}
+
+	pw_thread_loop_unlock(obs_pw->thread_loop);
 }

--- a/src/pipewire.h
+++ b/src/pipewire.h
@@ -66,3 +66,4 @@ void obs_pipewire_stream_set_resolution(obs_pipewire_stream *obs_pw, const struc
 
 void obs_pipewire_stream_set_name(obs_pipewire_stream *obs_pw_stream, const char *name);
 
+void obs_pipewire_connect_to_output(obs_pipewire_stream *obs_pw_stream, uint32_t port_id);

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -22,6 +22,7 @@ with this program. If not, see <https://www.gnu.org/licenses/>
 #include <plugin-support.h>
 #include <util/dstr.h>
 #include "pipewire.h"
+#include <spa/utils/dict.h>
 
 #if !PW_CHECK_VERSION(1, 2, 7)
 #define PW_KEY_NODE_SUPPORTS_REQUEST        "node.supports-request"
@@ -34,12 +35,19 @@ MODULE_EXPORT const char *obs_module_description(void)
 	return "Generic PipeWire video source";
 }
 
+struct _pipewire_source {
+	uint32_t id;
+	struct dstr name;
+};
+
 struct pipewire_video_capture {
 	obs_source_t *source;
 	obs_data_t *settings;
 
 	uint32_t pipewire_node;
 	bool double_buffering;
+	DARRAY(uint32_t) video_nodes;
+	DARRAY(struct _pipewire_source) available_sources;
 
 	obs_pipewire *obs_pw;
 	obs_pipewire_stream *obs_pw_stream;
@@ -62,6 +70,76 @@ void pipewire_video_rename(void *param, calldata_t *data)
 	obs_pipewire_stream_set_name(capture->obs_pw_stream, calldata_string(data, "new_name"));
 }
 
+static void obs_pipewire_registry_event_global(void *data, uint32_t id, uint32_t permissions,
+					       const char *type, uint32_t version,
+					       const struct spa_dict *props)
+{
+	UNUSED_PARAMETER(permissions);
+	UNUSED_PARAMETER(version);
+
+	struct pipewire_video_capture *capture = data;
+
+	if (!capture || !props) {
+		return;
+	}
+
+	if (strcmp(type, PW_TYPE_INTERFACE_Node) == 0) {
+		const char *media_class = spa_dict_lookup(props, PW_KEY_MEDIA_CLASS);
+		if (!media_class) {
+			return;
+		}
+		if (strcmp(media_class, "Stream/Output/Video") != 0) {
+			return;
+		}
+		da_push_back(capture->video_nodes, &id);
+	} else if (strcmp(type, PW_TYPE_INTERFACE_Port) == 0) {
+		const char *direction = spa_dict_lookup(props, PW_KEY_PORT_DIRECTION);
+		if (strcmp(direction, "out") != 0) {
+			return;
+		}
+
+		const char *node_id_str = spa_dict_lookup(props, PW_KEY_NODE_ID);
+		if (!node_id_str) {
+			return;
+		}
+		uint32_t node_id = strtoul(node_id_str, NULL, 10);
+		if (da_find(capture->video_nodes, &node_id, 0) == DARRAY_INVALID) {
+			return;
+		}
+
+		struct _pipewire_source source = {
+			.id = id,
+		};
+		dstr_init_copy(&source.name, spa_dict_lookup(props, PW_KEY_PORT_ALIAS));
+		da_push_back(capture->available_sources, &source);
+	}
+}
+
+static void obs_pipewire_registry_event_global_remove(void *data, uint32_t id)
+{
+	struct pipewire_video_capture *capture = data;
+	if (!capture) {
+		return;
+	}
+
+	da_erase_item(capture->video_nodes, &id);
+
+	for (size_t i = 0; i < capture->available_sources.num; ++i) {
+		struct _pipewire_source source = capture->available_sources.array[i];
+		if (source.id == id) {
+			dstr_free(&source.name);
+			da_erase(capture->available_sources, i);
+			break;
+		}
+	}
+}
+
+static const struct pw_registry_events registry_events = {
+        .version = PW_VERSION_REGISTRY_EVENTS,
+        .global = obs_pipewire_registry_event_global,
+	.global_remove = obs_pipewire_registry_event_global_remove,
+};
+
 static void *pipewire_video_capture_create(obs_data_t *settings, obs_source_t *source)
 {
 	UNUSED_PARAMETER(settings);
@@ -71,8 +149,10 @@ static void *pipewire_video_capture_create(obs_data_t *settings, obs_source_t *s
 	capture = bzalloc(sizeof(struct pipewire_video_capture));
 	capture->source = source;
 	capture->double_buffering = obs_data_get_bool(settings, "DoubleBuffering");
+	da_init(capture->video_nodes);
+	da_init(capture->available_sources);
 
-	capture->obs_pw = obs_pipewire_connect(NULL, NULL);
+	capture->obs_pw = obs_pipewire_connect(&registry_events, capture);
 	if (!capture->obs_pw) {
 		bfree(capture);
 		return NULL;
@@ -123,6 +203,13 @@ static void pipewire_video_capture_destroy(void *data)
 	signal_handler_t *sh = obs_source_get_signal_handler(capture->source);
 	signal_handler_disconnect(sh, "rename", pipewire_video_rename, capture);
 
+	da_free(capture->video_nodes);
+	for (size_t i = 0; i < capture->available_sources.num; ++i) {
+		struct _pipewire_source source = capture->available_sources.array[i];
+		dstr_free(&source.name);
+	}
+	da_free(capture->available_sources);
+
 	if (capture->obs_pw_stream) {
 		obs_pipewire_stream_destroy(capture->obs_pw_stream);
 		capture->obs_pw_stream = NULL;
@@ -139,10 +226,23 @@ static void pipewire_video_capture_get_defaults(obs_data_t *settings)
 
 static obs_properties_t *pipewire_video_capture_get_properties(void *data)
 {
-	UNUSED_PARAMETER(data);
 	obs_properties_t *properties;
 
 	properties = obs_properties_create();
+
+	obs_property_t *sources_list = obs_properties_add_list(properties, "CaptureSource", obs_module_text("Capture Source"), OBS_COMBO_TYPE_LIST, OBS_COMBO_FORMAT_INT);
+
+	struct pipewire_video_capture *capture = data;
+	if (capture) {
+		for (size_t i = 0; i < capture->available_sources.num; ++i) {
+			struct _pipewire_source source = capture->available_sources.array[i];
+			struct dstr name;
+			dstr_init(&name);
+			dstr_printf(&name, "%s (id: %u)", source.name.array, source.id);
+			obs_property_list_add_int(sources_list, name.array, source.id);
+			dstr_free(&name);
+		}
+	}
 
 	obs_properties_add_bool(properties, "DoubleBuffering", obs_module_text("DoubleBuffering"));
 

--- a/src/plugin-main.c
+++ b/src/plugin-main.c
@@ -258,6 +258,8 @@ static void pipewire_video_capture_update(void *data, obs_data_t *settings)
 
 	if (capture->obs_pw_stream)
 		obs_pipewire_stream_set_double_buffering(capture->obs_pw_stream, capture->double_buffering);
+
+	obs_pipewire_connect_to_output(capture->obs_pw_stream, obs_data_get_int(settings, "CaptureSource"));
 }
 
 static void pipewire_video_capture_show(void *data)


### PR DESCRIPTION
Instead of having to use a third party tool to link an output source, use a dropdown list in the properties page that shows the possible sources and then create a link with the source the user chooses.

Sources can still be linked with a third party tool if the user wants to.